### PR TITLE
詳細画面の作成

### DIFF
--- a/SwiftUIGithubSearch.xcodeproj/project.pbxproj
+++ b/SwiftUIGithubSearch.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		AA24EDFD29B9AA100089EC85 /* RepositoryDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EDFC29B9AA100089EC85 /* RepositoryDetailResponse.swift */; };
 		AA24EDFF29B9AB050089EC85 /* RepositoryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EDFE29B9AB050089EC85 /* RepositoryDetail.swift */; };
+		AA24EE0129B9F7A80089EC85 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0029B9F7A80089EC85 /* DetailViewModel.swift */; };
+		AA24EE0329B9F7D60089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */; };
+		AA24EE0629BA06260089EC85 /* IconWithText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0529BA06260089EC85 /* IconWithText.swift */; };
+		AA24EE0829BA0C570089EC85 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0729BA0C570089EC85 /* AppError.swift */; };
 		AA5947B529B718C300C84427 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = AA5947B429B718C300C84427 /* Factory */; };
 		AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
 		AA5947BF29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
@@ -56,6 +60,10 @@
 /* Begin PBXFileReference section */
 		AA24EDFC29B9AA100089EC85 /* RepositoryDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailResponse.swift; sourceTree = "<group>"; };
 		AA24EDFE29B9AB050089EC85 /* RepositoryDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetail.swift; sourceTree = "<group>"; };
+		AA24EE0029B9F7A80089EC85 /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
+		AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailUiState.swift; sourceTree = "<group>"; };
+		AA24EE0529BA06260089EC85 /* IconWithText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconWithText.swift; sourceTree = "<group>"; };
+		AA24EE0729BA0C570089EC85 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		AA5947BD29B71D7100C84427 /* DetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
 		AA5947C129B71E4C00C84427 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		AA5947C329B71F2500C84427 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -118,6 +126,15 @@
 			path = FetchRepositoryDetail;
 			sourceTree = "<group>";
 		};
+		AA24EE0429BA060E0089EC85 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				AA24EE0529BA06260089EC85 /* IconWithText.swift */,
+				AA24EE0729BA0C570089EC85 /* AppError.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 		AA5947B029B712E200C84427 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -147,6 +164,7 @@
 		AA5947B829B71C6D00C84427 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				AA24EE0429BA060E0089EC85 /* Component */,
 				AA5947BC29B71CBF00C84427 /* Detail */,
 				AA5947BA29B71CA600C84427 /* Search */,
 			);
@@ -175,6 +193,8 @@
 			isa = PBXGroup;
 			children = (
 				AA5947BD29B71D7100C84427 /* DetailScreen.swift */,
+				AA24EE0029B9F7A80089EC85 /* DetailViewModel.swift */,
+				AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -469,12 +489,16 @@
 				AA5947C429B71F2500C84427 /* HTTPMethod.swift in Sources */,
 				AAE789A029B87EF000A9DEE2 /* GithubErrorResponse.swift in Sources */,
 				AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */,
+				AA24EE0329B9F7D60089EC85 /* DetailUiState.swift in Sources */,
 				AA5947CE29B73A4B00C84427 /* SearchViewModel.swift in Sources */,
 				AA5947DC29B741AB00C84427 /* GithubService.swift in Sources */,
 				AA5947C829B71FEB00C84427 /* APIError.swift in Sources */,
+				AA24EE0129B9F7A80089EC85 /* DetailViewModel.swift in Sources */,
 				AA5947D329B73FC300C84427 /* GithubRepoRepository.swift in Sources */,
 				AA5947F129B7689800C84427 /* FakeGithubRepoRepository.swift in Sources */,
+				AA24EE0829BA0C570089EC85 /* AppError.swift in Sources */,
 				AAE789A429B8823B00A9DEE2 /* ApplicationError.swift in Sources */,
+				AA24EE0629BA06260089EC85 /* IconWithText.swift in Sources */,
 				AA24EDFD29B9AA100089EC85 /* RepositoryDetailResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftUIGithubSearch.xcodeproj/project.pbxproj
+++ b/SwiftUIGithubSearch.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		AA24EE0329B9F7D60089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */; };
 		AA24EE0629BA06260089EC85 /* IconWithText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0529BA06260089EC85 /* IconWithText.swift */; };
 		AA24EE0829BA0C570089EC85 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0729BA0C570089EC85 /* AppError.swift */; };
+		AA24EE0D29BA13B70089EC85 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */; };
+		AA24EE0E29BA13B70089EC85 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */; };
+		AA24EE0F29BA13B70089EC85 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */; };
+		AA24EE1029BA13B70089EC85 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */; };
+		AA24EE1129BA13B70089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */; };
+		AA24EE1229BA13B70089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */; };
 		AA5947B529B718C300C84427 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = AA5947B429B718C300C84427 /* Factory */; };
 		AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
 		AA5947BF29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
@@ -64,6 +70,9 @@
 		AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailUiState.swift; sourceTree = "<group>"; };
 		AA24EE0529BA06260089EC85 /* IconWithText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconWithText.swift; sourceTree = "<group>"; };
 		AA24EE0729BA0C570089EC85 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
+		AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
+		AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
+		AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailUiState.swift; sourceTree = "<group>"; };
 		AA5947BD29B71D7100C84427 /* DetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
 		AA5947C129B71E4C00C84427 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		AA5947C329B71F2500C84427 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -135,6 +144,16 @@
 			path = Component;
 			sourceTree = "<group>";
 		};
+		AA24EE0929BA13B70089EC85 /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */,
+				AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */,
+				AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */,
+			);
+			name = Detail;
+			sourceTree = "<group>";
+		};
 		AA5947B029B712E200C84427 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -193,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				AA5947BD29B71D7100C84427 /* DetailScreen.swift */,
+				AA24EE0929BA13B70089EC85 /* Detail */,
 				AA24EE0029B9F7A80089EC85 /* DetailViewModel.swift */,
 				AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */,
 			);
@@ -484,16 +504,19 @@
 				AA5947D929B7413C00C84427 /* GithubRepoRepositoryImpl.swift in Sources */,
 				AA5947D029B73AD900C84427 /* UiState.swift in Sources */,
 				AA5947C229B71E4C00C84427 /* HTTPStatusCode.swift in Sources */,
+				AA24EE0F29BA13B70089EC85 /* DetailScreen.swift in Sources */,
 				AA5947F329B78CE300C84427 /* GithubApiHttpClient.swift in Sources */,
 				AA5947DE29B7459A00C84427 /* Container.swift in Sources */,
 				AA5947C429B71F2500C84427 /* HTTPMethod.swift in Sources */,
 				AAE789A029B87EF000A9DEE2 /* GithubErrorResponse.swift in Sources */,
 				AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */,
+				AA24EE0D29BA13B70089EC85 /* DetailViewModel.swift in Sources */,
 				AA24EE0329B9F7D60089EC85 /* DetailUiState.swift in Sources */,
 				AA5947CE29B73A4B00C84427 /* SearchViewModel.swift in Sources */,
 				AA5947DC29B741AB00C84427 /* GithubService.swift in Sources */,
 				AA5947C829B71FEB00C84427 /* APIError.swift in Sources */,
 				AA24EE0129B9F7A80089EC85 /* DetailViewModel.swift in Sources */,
+				AA24EE1129BA13B70089EC85 /* DetailUiState.swift in Sources */,
 				AA5947D329B73FC300C84427 /* GithubRepoRepository.swift in Sources */,
 				AA5947F129B7689800C84427 /* FakeGithubRepoRepository.swift in Sources */,
 				AA24EE0829BA0C570089EC85 /* AppError.swift in Sources */,
@@ -515,9 +538,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA24EE1029BA13B70089EC85 /* DetailScreen.swift in Sources */,
 				AAC7D81A29B70A8100E62354 /* SwiftUIGithubSearchUITests.swift in Sources */,
+				AA24EE1229BA13B70089EC85 /* DetailUiState.swift in Sources */,
 				AAC7D81C29B70A8100E62354 /* SwiftUIGithubSearchUITestsLaunchTests.swift in Sources */,
 				AA5947BF29B71D7100C84427 /* DetailScreen.swift in Sources */,
+				AA24EE0E29BA13B70089EC85 /* DetailViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUIGithubSearch.xcodeproj/project.pbxproj
+++ b/SwiftUIGithubSearch.xcodeproj/project.pbxproj
@@ -13,12 +13,6 @@
 		AA24EE0329B9F7D60089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */; };
 		AA24EE0629BA06260089EC85 /* IconWithText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0529BA06260089EC85 /* IconWithText.swift */; };
 		AA24EE0829BA0C570089EC85 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0729BA0C570089EC85 /* AppError.swift */; };
-		AA24EE0D29BA13B70089EC85 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */; };
-		AA24EE0E29BA13B70089EC85 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */; };
-		AA24EE0F29BA13B70089EC85 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */; };
-		AA24EE1029BA13B70089EC85 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */; };
-		AA24EE1129BA13B70089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */; };
-		AA24EE1229BA13B70089EC85 /* DetailUiState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */; };
 		AA5947B529B718C300C84427 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = AA5947B429B718C300C84427 /* Factory */; };
 		AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
 		AA5947BF29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
@@ -70,9 +64,6 @@
 		AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailUiState.swift; sourceTree = "<group>"; };
 		AA24EE0529BA06260089EC85 /* IconWithText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconWithText.swift; sourceTree = "<group>"; };
 		AA24EE0729BA0C570089EC85 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
-		AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
-		AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
-		AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailUiState.swift; sourceTree = "<group>"; };
 		AA5947BD29B71D7100C84427 /* DetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
 		AA5947C129B71E4C00C84427 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		AA5947C329B71F2500C84427 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -144,16 +135,6 @@
 			path = Component;
 			sourceTree = "<group>";
 		};
-		AA24EE0929BA13B70089EC85 /* Detail */ = {
-			isa = PBXGroup;
-			children = (
-				AA24EE0A29BA13B70089EC85 /* DetailViewModel.swift */,
-				AA24EE0B29BA13B70089EC85 /* DetailScreen.swift */,
-				AA24EE0C29BA13B70089EC85 /* DetailUiState.swift */,
-			);
-			name = Detail;
-			sourceTree = "<group>";
-		};
 		AA5947B029B712E200C84427 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -212,7 +193,6 @@
 			isa = PBXGroup;
 			children = (
 				AA5947BD29B71D7100C84427 /* DetailScreen.swift */,
-				AA24EE0929BA13B70089EC85 /* Detail */,
 				AA24EE0029B9F7A80089EC85 /* DetailViewModel.swift */,
 				AA24EE0229B9F7D60089EC85 /* DetailUiState.swift */,
 			);
@@ -504,19 +484,16 @@
 				AA5947D929B7413C00C84427 /* GithubRepoRepositoryImpl.swift in Sources */,
 				AA5947D029B73AD900C84427 /* UiState.swift in Sources */,
 				AA5947C229B71E4C00C84427 /* HTTPStatusCode.swift in Sources */,
-				AA24EE0F29BA13B70089EC85 /* DetailScreen.swift in Sources */,
 				AA5947F329B78CE300C84427 /* GithubApiHttpClient.swift in Sources */,
 				AA5947DE29B7459A00C84427 /* Container.swift in Sources */,
 				AA5947C429B71F2500C84427 /* HTTPMethod.swift in Sources */,
 				AAE789A029B87EF000A9DEE2 /* GithubErrorResponse.swift in Sources */,
 				AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */,
-				AA24EE0D29BA13B70089EC85 /* DetailViewModel.swift in Sources */,
 				AA24EE0329B9F7D60089EC85 /* DetailUiState.swift in Sources */,
 				AA5947CE29B73A4B00C84427 /* SearchViewModel.swift in Sources */,
 				AA5947DC29B741AB00C84427 /* GithubService.swift in Sources */,
 				AA5947C829B71FEB00C84427 /* APIError.swift in Sources */,
 				AA24EE0129B9F7A80089EC85 /* DetailViewModel.swift in Sources */,
-				AA24EE1129BA13B70089EC85 /* DetailUiState.swift in Sources */,
 				AA5947D329B73FC300C84427 /* GithubRepoRepository.swift in Sources */,
 				AA5947F129B7689800C84427 /* FakeGithubRepoRepository.swift in Sources */,
 				AA24EE0829BA0C570089EC85 /* AppError.swift in Sources */,
@@ -538,12 +515,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA24EE1029BA13B70089EC85 /* DetailScreen.swift in Sources */,
 				AAC7D81A29B70A8100E62354 /* SwiftUIGithubSearchUITests.swift in Sources */,
-				AA24EE1229BA13B70089EC85 /* DetailUiState.swift in Sources */,
 				AAC7D81C29B70A8100E62354 /* SwiftUIGithubSearchUITestsLaunchTests.swift in Sources */,
 				AA5947BF29B71D7100C84427 /* DetailScreen.swift in Sources */,
-				AA24EE0E29BA13B70089EC85 /* DetailViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUIGithubSearch.xcodeproj/project.pbxproj
+++ b/SwiftUIGithubSearch.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA24EDFD29B9AA100089EC85 /* RepositoryDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EDFC29B9AA100089EC85 /* RepositoryDetailResponse.swift */; };
+		AA24EDFF29B9AB050089EC85 /* RepositoryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24EDFE29B9AB050089EC85 /* RepositoryDetail.swift */; };
 		AA5947B529B718C300C84427 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = AA5947B429B718C300C84427 /* Factory */; };
 		AA5947BE29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
 		AA5947BF29B71D7100C84427 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5947BD29B71D7100C84427 /* DetailScreen.swift */; };
@@ -52,6 +54,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA24EDFC29B9AA100089EC85 /* RepositoryDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailResponse.swift; sourceTree = "<group>"; };
+		AA24EDFE29B9AB050089EC85 /* RepositoryDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetail.swift; sourceTree = "<group>"; };
 		AA5947BD29B71D7100C84427 /* DetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
 		AA5947C129B71E4C00C84427 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		AA5947C329B71F2500C84427 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -106,6 +110,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AA24EDFB29B9A9E60089EC85 /* FetchRepositoryDetail */ = {
+			isa = PBXGroup;
+			children = (
+				AA24EDFC29B9AA100089EC85 /* RepositoryDetailResponse.swift */,
+			);
+			path = FetchRepositoryDetail;
+			sourceTree = "<group>";
+		};
 		AA5947B029B712E200C84427 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -189,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				AA5947D529B7406F00C84427 /* RepositorySummary.swift */,
+				AA24EDFE29B9AB050089EC85 /* RepositoryDetail.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -215,6 +228,7 @@
 		AA5947DF29B749E200C84427 /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				AA24EDFB29B9A9E60089EC85 /* FetchRepositoryDetail */,
 				AA5947E029B749F100C84427 /* SearchRepositories */,
 				AAE7899F29B87EF000A9DEE2 /* GithubErrorResponse.swift */,
 			);
@@ -442,6 +456,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA24EDFF29B9AB050089EC85 /* RepositoryDetail.swift in Sources */,
 				AA5947E329B74A1D00C84427 /* SearchRepositoriesResponse.swift in Sources */,
 				AA5947D629B7406F00C84427 /* RepositorySummary.swift in Sources */,
 				AAC7D80129B70A7F00E62354 /* SearchScreen.swift in Sources */,
@@ -460,6 +475,7 @@
 				AA5947D329B73FC300C84427 /* GithubRepoRepository.swift in Sources */,
 				AA5947F129B7689800C84427 /* FakeGithubRepoRepository.swift in Sources */,
 				AAE789A429B8823B00A9DEE2 /* ApplicationError.swift in Sources */,
+				AA24EDFD29B9AA100089EC85 /* RepositoryDetailResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUIGithubSearch/Data/API/Github/GithubApiHttpClient.swift
+++ b/SwiftUIGithubSearch/Data/API/Github/GithubApiHttpClient.swift
@@ -21,7 +21,7 @@ final class GithubApiHttpClientImpl: GithubApiHttpClient {
         do {
             (data, response) =  try await URLSession.shared.data(for: request.asURLRequest())
         } catch {
-            // 通信タイムアウトなどのエラーハンドリング - START
+            // 通信タイムアウトなどの接続エラーハンドリング - START
             let apiError: APIError
             if let error = error as? NSError, error.domain == NSURLErrorDomain {
                     // NSURLErrorTimedOut: 接続タイムアウト, NSURLErrorCannotFindHost: ホストが見つからなかったため、接続に失敗
@@ -31,7 +31,7 @@ final class GithubApiHttpClientImpl: GithubApiHttpClient {
                 apiError = .unexpected("unexpected: \(error.localizedDescription)")
                 throw apiError
             }
-            // 通信タイムアウトなどのエラーハンドリング - END
+            // 通信タイムアウトなどの接続エラーハンドリング - END
         }
         
         // http status code 200以外のエラーハンドリング - START

--- a/SwiftUIGithubSearch/Data/API/Github/GithubService.swift
+++ b/SwiftUIGithubSearch/Data/API/Github/GithubService.swift
@@ -59,8 +59,8 @@ enum GithubService {
         }
         
         func asURLRequest() throws -> URLRequest {
-            var urlComponents = URLComponents(string: baseURL + path)!
-            var request = URLRequest(url: urlComponents.url!) // timeoutInterval: 0.0001
+            let urlComponents = URLComponents(string: baseURL + path)!
+            var request = URLRequest(url: urlComponents.url!)
             request.setHeaders(apiKey: apiKey)
             return request
         }

--- a/SwiftUIGithubSearch/Data/API/Github/Response/FetchRepositoryDetail/RepositoryDetailResponse.swift
+++ b/SwiftUIGithubSearch/Data/API/Github/Response/FetchRepositoryDetail/RepositoryDetailResponse.swift
@@ -1,0 +1,38 @@
+//
+//  RepositoryDetailResponse.swift
+//  SwiftUIGithubSearch
+//
+//  Created by LeoAndo on 2023/03/09.
+//
+
+struct RepositoryDetailResponse : Decodable {
+    let forks_count: Int
+    let id: Int
+    let name: String
+    let open_issues_count: Int
+    let owner: Owner
+    let stargazers_count: Int
+    let watchers_count: Int
+    let language: String?
+    let description: String?
+    struct Owner : Decodable {
+        let avatar_url: String
+        let id: Int
+        let node_id: Int
+    }
+}
+
+extension RepositoryDetailResponse {
+    func toModel() -> RepositoryDetail {
+        RepositoryDetail(
+            name: self.name,
+            owner_avatar_url: self.owner.avatar_url,
+            stargazers_count: self.stargazers_count,
+            forks_count: self.forks_count,
+            open_issues_count: self.open_issues_count,
+            watchers_count: self.watchers_count,
+            language: self.language,
+            description: self.description
+        )
+    }
+}

--- a/SwiftUIGithubSearch/Data/API/Github/Response/FetchRepositoryDetail/RepositoryDetailResponse.swift
+++ b/SwiftUIGithubSearch/Data/API/Github/Response/FetchRepositoryDetail/RepositoryDetailResponse.swift
@@ -18,7 +18,6 @@ struct RepositoryDetailResponse : Decodable {
     struct Owner : Decodable {
         let avatar_url: String
         let id: Int
-        let node_id: Int
     }
 }
 
@@ -26,11 +25,11 @@ extension RepositoryDetailResponse {
     func toModel() -> RepositoryDetail {
         RepositoryDetail(
             name: self.name,
-            owner_avatar_url: self.owner.avatar_url,
-            stargazers_count: self.stargazers_count,
-            forks_count: self.forks_count,
-            open_issues_count: self.open_issues_count,
-            watchers_count: self.watchers_count,
+            ownerAvatarUrl: self.owner.avatar_url,
+            stargazersCount: self.stargazers_count,
+            forksCount: self.forks_count,
+            openIssuesCount: self.open_issues_count,
+            watchersCount: self.watchers_count,
             language: self.language,
             description: self.description
         )

--- a/SwiftUIGithubSearch/Data/Repository/Fake/FakeGithubRepoRepository.swift
+++ b/SwiftUIGithubSearch/Data/Repository/Fake/FakeGithubRepoRepository.swift
@@ -18,4 +18,7 @@ final class FakeGithubRepoRepository: GithubRepoRepository {
     func searchRepositories(query: String, page: Int) async throws -> [RepositorySummary] {
          successData
     }
+    func fetchRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail {
+        RepositoryDetail(name: "repoName01", owner_avatar_url: "https://avatars.githubusercontent.com/u/5429470?v=4", stargazers_count: 100, forks_count: 200, open_issues_count: 300, watchers_count: 400, language: "Dart", description: "flutter description01")
+    }
 }

--- a/SwiftUIGithubSearch/Data/Repository/Fake/FakeGithubRepoRepository.swift
+++ b/SwiftUIGithubSearch/Data/Repository/Fake/FakeGithubRepoRepository.swift
@@ -18,7 +18,7 @@ final class FakeGithubRepoRepository: GithubRepoRepository {
     func searchRepositories(query: String, page: Int) async throws -> [RepositorySummary] {
          successData
     }
-    func fetchRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail {
-        RepositoryDetail(name: "repoName01", owner_avatar_url: "https://avatars.githubusercontent.com/u/5429470?v=4", stargazers_count: 100, forks_count: 200, open_issues_count: 300, watchers_count: 400, language: "Dart", description: "flutter description01")
+    func getRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail {
+        RepositoryDetail(name: "repoName01", ownerAvatarUrl: "https://avatars.githubusercontent.com/u/5429470?v=4", stargazersCount: 100, forksCount: 200, openIssuesCount: 300, watchersCount: 400, language: "Dart", description: "flutter description01")
     }
 }

--- a/SwiftUIGithubSearch/Data/Repository/GithubRepoRepositoryImpl.swift
+++ b/SwiftUIGithubSearch/Data/Repository/GithubRepoRepositoryImpl.swift
@@ -8,13 +8,14 @@
 import Foundation
 
 final class GithubRepoRepositoryImpl: GithubRepoRepository {
-    
     private var client: GithubApiHttpClient
-
     init(client: GithubApiHttpClient) {
         self.client = client
     }
     func searchRepositories(query: String, page: Int) async throws -> [RepositorySummary] {
-        try await client.fetch(GithubService.SearchRepositories(query: query, page: page)).toModels()
+        try await client.fetch(GithubService.SearchRepositories(query, page)).toModels()
+    }
+    func fetchRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail {
+        try await client.fetch(GithubService.FetchRepositoryDetail(ownerName, repositoryName)).toModel()
     }
 }

--- a/SwiftUIGithubSearch/Data/Repository/GithubRepoRepositoryImpl.swift
+++ b/SwiftUIGithubSearch/Data/Repository/GithubRepoRepositoryImpl.swift
@@ -15,7 +15,7 @@ final class GithubRepoRepositoryImpl: GithubRepoRepository {
     func searchRepositories(query: String, page: Int) async throws -> [RepositorySummary] {
         try await client.fetch(GithubService.SearchRepositories(query, page)).toModels()
     }
-    func fetchRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail {
+    func getRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail {
         try await client.fetch(GithubService.FetchRepositoryDetail(ownerName, repositoryName)).toModel()
     }
 }

--- a/SwiftUIGithubSearch/Domain/Repository/GithubRepoRepository.swift
+++ b/SwiftUIGithubSearch/Domain/Repository/GithubRepoRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol GithubRepoRepository {
     func searchRepositories(query: String, page: Int) async throws -> [RepositorySummary]
-    func fetchRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail
+    func getRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail
 }

--- a/SwiftUIGithubSearch/Domain/Repository/GithubRepoRepository.swift
+++ b/SwiftUIGithubSearch/Domain/Repository/GithubRepoRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
-protocol GithubRepoRepository: AnyObject {
+protocol GithubRepoRepository {
     func searchRepositories(query: String, page: Int) async throws -> [RepositorySummary]
+    func fetchRepositoryDetail(ownerName: String, repositoryName: String) async throws -> RepositoryDetail
 }

--- a/SwiftUIGithubSearch/Domain/RepositoryDetail.swift
+++ b/SwiftUIGithubSearch/Domain/RepositoryDetail.swift
@@ -1,0 +1,16 @@
+//
+//  RepositoryDetail.swift
+//  SwiftUIGithubSearch
+//
+//  Created by LeoAndo on 2023/03/09.
+//
+struct RepositoryDetail: Decodable {
+    let name: String
+    let owner_avatar_url: String
+    let stargazers_count: Int
+    let forks_count: Int
+    let open_issues_count: Int
+    let watchers_count: Int
+    let language: String?
+    let description: String?
+}

--- a/SwiftUIGithubSearch/Domain/RepositoryDetail.swift
+++ b/SwiftUIGithubSearch/Domain/RepositoryDetail.swift
@@ -6,11 +6,11 @@
 //
 struct RepositoryDetail: Decodable {
     let name: String
-    let owner_avatar_url: String
-    let stargazers_count: Int
-    let forks_count: Int
-    let open_issues_count: Int
-    let watchers_count: Int
+    let ownerAvatarUrl: String
+    let stargazersCount: Int
+    let forksCount: Int
+    let openIssuesCount: Int
+    let watchersCount: Int
     let language: String?
     let description: String?
 }

--- a/SwiftUIGithubSearch/Domain/RepositorySummary.swift
+++ b/SwiftUIGithubSearch/Domain/RepositorySummary.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct RepositorySummary : Decodable, Identifiable {
+struct RepositorySummary : Decodable, Identifiable, Hashable {
     let id: Int
     let name: String
     let ownerName: String

--- a/SwiftUIGithubSearch/UI/Component/AppError.swift
+++ b/SwiftUIGithubSearch/UI/Component/AppError.swift
@@ -1,0 +1,43 @@
+//
+//  AppError.swift
+//  SwiftUIGithubSearch
+//
+//  Created by LeoAndo on 2023/03/09.
+//
+
+import SwiftUI
+
+/// エラー表示用共通View
+struct AppError: View {
+    var message: String = "default message: error"
+    var padding: EdgeInsets = EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
+    let onReload: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(message)
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.red)
+                .lineLimit(1)
+            Button(action:  {
+                onReload()
+            }, label:  {
+                Text("reload")
+            })
+        }.padding(padding)
+    }
+}
+
+struct AppError_Previews: PreviewProvider {
+    static var previews: some View {
+        AppError(message: "error.") {
+            
+        }
+        AppError(message: "long message asadfveagverrbvergbergvergvergvergvergverg") {
+            
+        }
+        AppError() {
+            
+        }
+    }
+}

--- a/SwiftUIGithubSearch/UI/Component/IconWithText.swift
+++ b/SwiftUIGithubSearch/UI/Component/IconWithText.swift
@@ -1,0 +1,35 @@
+//
+//  IconWithText.swift
+//  SwiftUIGithubSearch
+//
+//  Created by LeoAndo on 2023/03/09.
+//
+
+import SwiftUI
+
+struct IconWithText: View {
+    let systemName: String
+    let text: String
+    var body: some View {
+        HStack {
+            Image(systemName: systemName)
+            Text(text).font(.body).lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading )
+        // .background(.orange) // debug
+        .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
+    }
+}
+
+struct IconWithText_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            // 正常系
+            IconWithText(systemName: "globe.americas", text: "Dart")
+            // 正常系: 長いメッセージ
+            IconWithText(systemName: "globe.americas", text: "AAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBB")
+            // 異常系: 不正な画像パス
+            IconWithText(systemName: "wgverewg", text: "Dart")
+        }
+    }
+}

--- a/SwiftUIGithubSearch/UI/Detail/DetailScreen.swift
+++ b/SwiftUIGithubSearch/UI/Detail/DetailScreen.swift
@@ -10,13 +10,75 @@ import SwiftUI
 struct DetailScreen: View {
     let name: String
     let ownerName: String
+    @StateObject var viewModel: DetailViewModel
     var body: some View {
-        Text("\(name) : \(ownerName)")
+        DetailScreenStateless(uiState: viewModel.uiState, ownerName: ownerName, onReload: {
+            viewModel.getRepositoryDetail(name: name, ownerName: ownerName)
+        })
+        .onAppear {
+            viewModel.getRepositoryDetail(name: name, ownerName: ownerName)
+        }
+    }
+}
+
+struct DetailScreenStateless: View {
+    let uiState: DetailUiState
+    let ownerName: String
+    let onReload: () -> Void
+    var body: some View {
+        switch self.uiState {
+        case .initial :
+            EmptyView()
+        case .loading:
+            ProgressView()
+        case .error(let message):
+            AppError(message: message) { onReload() }
+        case .data(let data):
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(spacing: 20) {
+                    AsyncImage(url: URL(string: data.detail.ownerAvatarUrl)) { phase in
+                        if let image = phase.image {
+                            // Displays the loaded image.
+                            image.resizable()
+                        } else if phase.error != nil {
+                            // Indicates an error.
+                            Image(systemName: "person.circle.fill").resizable()
+                        } else {
+                            // Acts as a placeholder.
+                            ProgressView()
+                        }
+                    }
+                    .frame(width: 200, height: 200 )
+                    //.background(Color.orange) // debug
+                    .clipShape(/*@START_MENU_TOKEN@*/Circle()/*@END_MENU_TOKEN@*/)
+                    
+                    Text(data.detail.name).font(.largeTitle)
+                    Text(ownerName).font(.title)
+                    Text(data.detail.description ?? "").font(.body).frame(maxWidth: .infinity, alignment: .leading).padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)).lineLimit(1)
+                    Text(data.detail.language ?? "").font(.body)
+                    
+                    IconWithText(systemName: "globe.americas", text: "\(data.detail.forksCount) forks")
+                    IconWithText(systemName: "moon.haze", text: "\(data.detail.stargazersCount) stars")
+                    IconWithText(systemName: "atom", text: "\(data.detail.watchersCount) watchers")
+                    IconWithText(systemName: "flame.fill", text: "open \(data.detail.openIssuesCount) issues")
+                }
+            }
+        }
     }
 }
 
 struct DetailScreen_Previews: PreviewProvider {
     static var previews: some View {
-        DetailScreen(name: "repo01", ownerName: "owner01")
+        let detailData: RepositoryDetail = RepositoryDetail(name: "repo01", ownerAvatarUrl: "https://avatars.githubusercontent.com/u/14101776?v=4", stargazersCount: 100, forksCount: 200, openIssuesCount: 300, watchersCount: 400, language: "Dart", description: "description abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz")
+        let detailErrorData: RepositoryDetail = RepositoryDetail(name: "repo01", ownerAvatarUrl: "errorUrl", stargazersCount: 100, forksCount: 200, openIssuesCount: 300, watchersCount: 400, language: nil, description: nil)
+        
+        Group {
+            DetailScreenStateless(uiState: .initial, ownerName: "owner01") {}
+            DetailScreenStateless(uiState: .loading, ownerName: "owner01"){}
+            DetailScreenStateless(uiState: .error("!!!!error!!!!"), ownerName: "owner01"){}
+            DetailScreenStateless(uiState: .data(DetailUiState.Data(detail: detailData)), ownerName: "owner01"){}
+            // Image取得失敗 & language と description nilケース
+            DetailScreenStateless(uiState: .data(DetailUiState.Data(detail: detailErrorData)), ownerName: "owner01"){}
+        }
     }
 }

--- a/SwiftUIGithubSearch/UI/Detail/DetailScreen.swift
+++ b/SwiftUIGithubSearch/UI/Detail/DetailScreen.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct DetailScreen: View {
+    let name: String
+    let ownerName: String
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("\(name) : \(ownerName)")
     }
 }
 
 struct DetailScreen_Previews: PreviewProvider {
     static var previews: some View {
-        DetailScreen()
+        DetailScreen(name: "repo01", ownerName: "owner01")
     }
 }

--- a/SwiftUIGithubSearch/UI/Detail/DetailUiState.swift
+++ b/SwiftUIGithubSearch/UI/Detail/DetailUiState.swift
@@ -1,0 +1,13 @@
+//
+//  UiState.swift
+//  SwiftUIGithubSearch
+//
+//  Created by LeoAndo on 2023/03/09.
+//
+enum DetailUiState {
+    struct Data { let detail: RepositoryDetail}
+    case initial
+    case loading
+    case data(Data)
+    case error(String)
+}

--- a/SwiftUIGithubSearch/UI/Detail/DetailViewModel.swift
+++ b/SwiftUIGithubSearch/UI/Detail/DetailViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  DetailViewModel.swift
+//  SwiftUIGithubSearch
+//
+//  Created by LeoAndo on 2023/03/09.
+//
+
+import Foundation
+import Factory
+
+@MainActor
+final class DetailViewModel : ObservableObject {
+    @Published var uiState: DetailUiState = DetailUiState.initial
+    private let repository = Container.shared.githubRepoRepository()
+    
+    func getRepositoryDetail(name: String, ownerName: String) {
+        Task {
+            do {
+                uiState = DetailUiState.loading
+                let result = try await repository.getRepositoryDetail(ownerName: ownerName, repositoryName: name)
+                self.uiState = DetailUiState.data(DetailUiState.Data(detail:result))
+            } catch {
+                guard let e =  error as? APIError else { return }
+                switch(e) {
+                case .http(let code, let message):
+                    self.uiState = DetailUiState.error("\(code) : \(message)")
+                case .unexpected(let message):
+                    self.uiState = DetailUiState.error("\(message)")
+                case .network(let message): // 接続エラー
+                    self.uiState = DetailUiState.error("\(message)")
+                }
+            }
+        }
+    }
+}

--- a/SwiftUIGithubSearch/UI/Search/SearchScreen.swift
+++ b/SwiftUIGithubSearch/UI/Search/SearchScreen.swift
@@ -11,9 +11,11 @@ import Factory
 struct SearchScreen: View {
     @StateObject var viewModel: SearchViewModel
     var body: some View {
-        MainContent(uiState: viewModel.uiState) { query in
+        MainContent(uiState: viewModel.uiState, onSubmit: { query in
             viewModel.searchRepositories(query: query, page: 1)
-        }
+        }, onReload: { query in
+            viewModel.searchRepositories(query: query, page: 1)
+        })
     }
 }
 
@@ -21,6 +23,7 @@ struct MainContent: View {
     let uiState: UiState
     let onSubmit: ((String) -> Void)
     @State var inputText = "" // TextFieldがBinding<String> に依存するのでStatelessにできない
+    let onReload: ((String) -> Void)
     var body: some View {
         NavigationStack {
             VStack() {
@@ -33,7 +36,7 @@ struct MainContent: View {
                 case .initial:
                     EmptyView()
                 case .error(let message):
-                    Text(message)
+                    AppError(message: message) { onReload(inputText) }
                 case .loading:
                     ProgressView("fetching…")
                         .progressViewStyle(CircularProgressViewStyle())
@@ -70,7 +73,7 @@ struct ScucessView: View {
                             // セル１行分のレイアウト - END
                         }
                     }.navigationDestination(for: RepositorySummary.self) { repository in
-                        DetailScreen(name: repository.name, ownerName: repository.ownerName)
+                        DetailScreen(name: repository.name, ownerName: repository.ownerName, viewModel: DetailViewModel())
                     }
                 }
             }
@@ -92,10 +95,10 @@ struct ContentView_Previews: PreviewProvider {
             // repositoryをfakeに差し替える - START
             // let _ = Container.shared.githubRepoRepository.register { FakeGithubRepoRepository() }
             // repositoryをfakeに差し替える - END
-            MainContent(uiState: .initial, onSubmit: {_ in }, inputText: "Flutter")
-            MainContent(uiState: UiState.loading, onSubmit: {_ in }, inputText: "Flutter")
-            MainContent(uiState:UiState.data(UiState.Data(repositories:successData)), onSubmit: {_ in }, inputText: "Flutter")
-            MainContent(uiState: UiState.error("Error!!!!"), onSubmit: {_ in }, inputText: "Flutter")
+            MainContent(uiState: .initial, onSubmit: {_ in }, inputText: "Flutter", onReload: {_ in })
+            MainContent(uiState: UiState.loading, onSubmit: {_ in }, inputText: "Flutter", onReload: {_ in })
+            MainContent(uiState:UiState.data(UiState.Data(repositories:successData)), onSubmit: {_ in }, inputText: "Flutter", onReload: {_ in })
+            MainContent(uiState: UiState.error("Error!!!!"), onSubmit: {_ in }, inputText: "Flutter", onReload: {_ in })
         }
     }
 }

--- a/SwiftUIGithubSearch/UI/Search/SearchScreen.swift
+++ b/SwiftUIGithubSearch/UI/Search/SearchScreen.swift
@@ -22,24 +22,26 @@ struct MainContent: View {
     let onSubmit: ((String) -> Void)
     @State var inputText = "" // TextFieldがBinding<String> に依存するのでStatelessにできない
     var body: some View {
-        VStack() {
-            TextField("キーワード", text: $inputText, prompt: Text("キーワードを入力してください"))
-                .onSubmit { onSubmit(inputText) }
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .padding()
-            Spacer()
-            switch self.uiState {
-            case .initial:
-                EmptyView()
-            case .error(let message):
-                Text(message)
-            case .loading:
-                ProgressView("fetching…")
-                    .progressViewStyle(CircularProgressViewStyle())
-            case .data(let data):
-                ScucessView(repositories: data.repositories)
+        NavigationStack {
+            VStack() {
+                TextField("キーワード", text: $inputText, prompt: Text("キーワードを入力してください"))
+                    .onSubmit { onSubmit(inputText) }
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                Spacer()
+                switch self.uiState {
+                case .initial:
+                    EmptyView()
+                case .error(let message):
+                    Text(message)
+                case .loading:
+                    ProgressView("fetching…")
+                        .progressViewStyle(CircularProgressViewStyle())
+                case .data(let data):
+                    ScucessView(repositories: data.repositories)
+                }
+                Spacer()
             }
-            Spacer()
         }
     }
 }
@@ -49,22 +51,28 @@ struct ScucessView: View {
     let repositories: [RepositorySummary]
     var body: some View {
         VStack(spacing: 0) {
-            if !repositories.isEmpty {
+            if repositories.isEmpty {
+                Text("result empty...")
+            } else {
                 ScrollView(.vertical, showsIndicators: true) {
                     LazyVStack(spacing: 0) {
                         ForEach(repositories) { repository in
-                            VStack(alignment: .leading) {
-                                Text(repository.name)
-                                Text(repository.ownerName)
-                                Divider()
+                            // セル１行分のレイアウト - START
+                            NavigationLink(value: repository) {
+                                VStack(alignment: .leading) {
+                                    Text(repository.name)
+                                    Text(repository.ownerName)
+                                    Divider()
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding([.leading, .trailing], 8)
                             }
-                            .frame(maxWidth: .infinity)
-                            .padding([.leading, .trailing], 8)
+                            // セル１行分のレイアウト - END
                         }
+                    }.navigationDestination(for: RepositorySummary.self) { repository in
+                        DetailScreen(name: repository.name, ownerName: repository.ownerName)
                     }
                 }
-            } else {
-                Text("result empty...")
             }
         }
     }


### PR DESCRIPTION
# issues (任意)
close #2 

# 修正内容 (必須)
- 詳細画面の作成(UIレイヤー)
- 詳細API連携 (data / domainレイヤー)
- 検索画面からの画面遷移処理の実装
  - ios16から推奨のNavigationStackを利用

  
# 実装メモ
NavigationStackで使うModelデータには、Hashableを実装する必要がある.
しないと以下のようなコンパイルエラーになる
<img width="1228" alt="スクリーンショット 2023-03-09 16 29 54" src="https://user-images.githubusercontent.com/16476224/223951229-782510fe-c40f-499f-8d74-d0dcf7139e4e.png">


# capture (任意)

## DetailScreen : Preview

### ローディング
<img width="376" alt="スクリーンショット 2023-03-09 22 09 22" src="https://user-images.githubusercontent.com/16476224/224032866-c485190d-4093-4e9f-9706-7a4ed2a9213d.png">

### 異常系 復旧ボタンあり
<img width="364" alt="スクリーンショット 2023-03-09 22 09 32" src="https://user-images.githubusercontent.com/16476224/224032903-5437c0b7-e7cb-40ff-b03f-acfc72f2f558.png">

### データ正常取得
<img width="389" alt="スクリーンショット 2023-03-09 22 09 44" src="https://user-images.githubusercontent.com/16476224/224032952-9b4f364b-8ee5-4456-9371-d5fd77fecd5d.png">

### Image取得失敗 & language と description nilケース
<img width="384" alt="スクリーンショット 2023-03-09 22 10 00" src="https://user-images.githubusercontent.com/16476224/224033019-f183a071-a7df-4b1a-b54c-df2a84b12a00.png">



# refs (任意)
**iOS16以降：NavigationStackを使った画面遷移を推奨している**
https://developer.apple.com/documentation/swiftui/navigationstack